### PR TITLE
Enable automatic battery icon display in Home Assistant

### DIFF
--- a/src/carconnectivity_plugins/mqtt_homeassistant/plugin.py
+++ b/src/carconnectivity_plugins/mqtt_homeassistant/plugin.py
@@ -350,7 +350,6 @@ class Plugin(BasePlugin):  # pylint: disable=too-many-instance-attributes
                                 'p': 'sensor',
                                 'device_class': 'battery',
                                 'state_class': 'measurement',
-                                'icon': 'mdi:battery',
                                 'name': f'SoC ({drive_id})',
                                 'state_topic': f'{self.mqtt_plugin.mqtt_client.prefix}{drive.level.get_absolute_path()}',
                                 'unique_id': f'{vin}_{drive_id}_level'


### PR DESCRIPTION
## Summary
This PR enables automatic battery icon display in Home Assistant for the electric vehicle State of Charge (SoC) sensor.

## Changes
- Removed static `icon: 'mdi:battery'` from the electric drive battery level sensor configuration
- Kept `device_class: 'battery'` and `state_class: 'measurement'` to enable automatic icon display

## Benefits
- Home Assistant will now automatically display dynamic battery icons based on the current charge level
- Icons will change contextually (e.g., battery-10, battery-30, battery-50, battery-80, battery-100, etc.)
- Provides better visual feedback to users about battery status at a glance
- Follows Home Assistant best practices for battery sensors

## Testing
- Configuration has been updated in `plugin.py`
- Compatible with existing Home Assistant MQTT discovery protocol