### PR TITLE
Provide via_device in vehicle discovery

### DIFF
--- a/src/carconnectivity_plugins/mqtt_homeassistant/plugin.py
+++ b/src/carconnectivity_plugins/mqtt_homeassistant/plugin.py
@@ -237,11 +237,13 @@ class Plugin(BasePlugin):  # pylint: disable=too-many-instance-attributes
         if not self.mqtt_plugin.mqtt_client.is_connected():
             return
         vin: str = vehicle.vin.value
+        car_connectivity_id: str = self.mqtt_plugin.mqtt_client.prefix.replace('/', '-')
         discovery_topic = f'{self.active_config["homeassistant_prefix"]}/device/{vin}/config'
         discovery_message = {
             'device': {
                 'ids': vin,
                 'sn': vin,
+                'via_device': car_connectivity_id,
             },
             'origin': {
                 'name': 'carconnectivity-plugin-mqtt',


### PR DESCRIPTION
Allows the linking between CarConnectivity and the various car plugins

Shows from CarConnectivity:
<img width="780" height="998" alt="image" src="https://github.com/user-attachments/assets/0f0a6c4c-047e-482d-839f-48ef77600125" />

From the vehicle a link back to CarConnectivity:
<img width="539" height="385" alt="image" src="https://github.com/user-attachments/assets/1ee87258-c423-4901-b6a4-53860f2693b0" />

