### PR TITLE
feat(discovery): publish Home Assistant entity for combustion oil_level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-- No unreleased changes so far
+### Added
+- Publish Home Assistant discovery for the combustion drive's `oil_level` (engine oil level)
 
 ## [0.6.5] - 2026-04-24
 ### Changed

--- a/src/carconnectivity_plugins/mqtt_homeassistant/plugin.py
+++ b/src/carconnectivity_plugins/mqtt_homeassistant/plugin.py
@@ -404,6 +404,19 @@ class Plugin(BasePlugin):  # pylint: disable=too-many-instance-attributes
                                     _, unit = drive.fuel_tank.available_capacity.in_locale(locale=self.mqtt_plugin.mqtt_client.locale)
                                     if unit is not None:
                                         discovery_message['cmps'][f'{vin}_{drive_id}_available_capacity']['unit_of_measurement'] = unit.value
+                        if drive.oil_level.enabled and drive.oil_level.value is not None:
+                            discovery_message['cmps'][f'{vin}_{drive_id}_oil_level'] = {
+                                'p': 'sensor',
+                                'state_class': 'measurement',
+                                'name': f'Oil level ({drive_id})',
+                                'icon': 'mdi:oil-level',
+                                'state_topic': f'{self.mqtt_plugin.mqtt_client.prefix}{drive.oil_level.get_absolute_path()}',
+                                'unique_id': f'{vin}_{drive_id}_oil_level'
+                            }
+                            if drive.oil_level.unit is not None:
+                                _, unit = drive.oil_level.in_locale(locale=self.mqtt_plugin.mqtt_client.locale)
+                                if unit is not None:
+                                    discovery_message['cmps'][f'{vin}_{drive_id}_oil_level']['unit_of_measurement'] = unit.value
                         if isinstance(drive, DieselDrive):
                             if drive.adblue_level.enabled and drive.adblue_level.value is not None:
                                 discovery_message['cmps'][f'{vin}_{drive_id}_adbluelevel'] = {


### PR DESCRIPTION
## Summary

Adds a Home Assistant discovery block for the combustion drive's `oil_level`
(engine oil level, %), so it is surfaced as an HA sensor instead of only living
on the raw MQTT topic.

The plugin builds discovery from explicit per-attribute blocks; `oil_level` had
none, so no entity was created. This mirrors the existing `level` / `adblue_level`
blocks (state_class measurement, `%` unit, `mdi:oil-level` icon).

## Dependency (draft)

Requires `oil_level` on `CombustionDrive` in the core:
tillsteinbach/CarConnectivity#161. Ready to un-draft once that lands.

## Related PRs (oil-level feature set)
- Core: tillsteinbach/CarConnectivity#161 — add `oil_level` to `CombustionDrive`
- Connector: mikrohard/CarConnectivity-connector-vw-eu-data-act#17 — map `oil_level_actual_level` → `drive.oil_level`
- HA plugin: tillsteinbach/CarConnectivity-plugin-mqtt_homeassistant#58 — publish the Home Assistant discovery entity