### PR TITLE
feat(discovery): publish Home Assistant binary_sensor for parking_brake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-- No unreleased changes so far
+### Added
+- Publish a Home Assistant binary_sensor for the vehicle's `parking_brake`
 
 ## [0.6.5] - 2026-04-24
 ### Changed

--- a/src/carconnectivity_plugins/mqtt_homeassistant/plugin.py
+++ b/src/carconnectivity_plugins/mqtt_homeassistant/plugin.py
@@ -298,6 +298,16 @@ class Plugin(BasePlugin):  # pylint: disable=too-many-instance-attributes
             }
             if vehicle.state.value_type is not None and issubclass(vehicle.state.value_type, Enum):
                 discovery_message['cmps'][f'{vin}_state']['options'] = [item.value for item in vehicle.state.value_type]
+        if vehicle.parking_brake.enabled and vehicle.parking_brake.value is not None:
+            discovery_message['cmps'][f'{vin}_parking_brake'] = {
+                'p': 'binary_sensor',
+                'name': 'Parking Brake',
+                'icon': 'mdi:car-brake-parking',
+                'state_topic': f'{self.mqtt_plugin.mqtt_client.prefix}{vehicle.parking_brake.get_absolute_path()}',
+                'payload_on': 'True',
+                'payload_off': 'False',
+                'unique_id': f'{vin}_parking_brake'
+            }
         if vehicle.connection_state.enabled and vehicle.connection_state.value is not None:
             discovery_message['cmps'][f'{vin}_connection_state'] = {
                 'p': 'sensor',


### PR DESCRIPTION
## Summary

Adds a Home Assistant discovery block for the vehicle's `parking_brake`
(binary_sensor, `on` = engaged), so it is surfaced as an HA entity instead of
only living on the raw MQTT topic. Mirrors the other vehicle-level entity blocks.

## Dependency (draft)

Requires `parking_brake` on the vehicle in the core:
tillsteinbach/CarConnectivity#162. Ready to un-draft once that lands.

## Related PRs
- Core: tillsteinbach/CarConnectivity#162 — add `parking_brake` to vehicles